### PR TITLE
Update away from deprecated names in latest Savi version.

### DIFF
--- a/src/IO.savi
+++ b/src/IO.savi
@@ -76,7 +76,7 @@
     from String = ""
   )
     asio_flags =
-      if Platform.windows (AsioEvent.read_write | AsioEvent.read_write_oneshot)
+      if Platform.is_windows (AsioEvent.read_write | AsioEvent.read_write_oneshot)
     connect_count = LibPonyOs.pony_os_connect_tcp(
       actor, host.cstring, service.cstring, from.cstring, asio_flags
     )
@@ -86,7 +86,7 @@
   // TODO: Make private or move to another package:
   :new new_from_fd_rw(actor AsioEventNotify, @_fd)
     asio_flags =
-      if Platform.windows (AsioEvent.read_write | AsioEvent.read_write_oneshot)
+      if Platform.is_windows (AsioEvent.read_write | AsioEvent.read_write_oneshot)
     @_event = AsioEvent.create(actor, @_fd, asio_flags, 0, True)
 
   // TODO: Make private or move to another package:
@@ -213,7 +213,7 @@
   :: All data currently available to be read from the socket will be read.
   :: However, if the connection is muted, a hard close will be done instead,
   :: closing the socket immediately with no more data being read from it.
-  :fun ref close Bool: if Platform.windows (@_close | @hard_close)
+  :fun ref close Bool: if Platform.is_windows (@_close | @hard_close)
   :fun ref _close Bool
     @_has_closed = True
 
@@ -243,7 +243,7 @@
     // So, we finish up here in a later call to this function by unsubscribing,
     // after the socket is no longer readable and we have no pending writes.
     if (
-      Platform.windows
+      Platform.is_windows
       && @has_closed && @_is_readable.not // TODO: && @_pending_sent == 0
     ) (
       AsioEvent.unsubscribe(@_event)
@@ -261,7 +261,7 @@
       // @_pending_writev.clear
       // @_pending_sent = 0
 
-      if Platform.windows.not (
+      if Platform.is_windows.not (
         AsioEvent.unsubscribe(@_event)
         @_is_readable = False
         @_is_writable = False

--- a/src/_WriteBuffer.savi
+++ b/src/_WriteBuffer.savi
@@ -38,7 +38,7 @@
     case (
     | @_write_total_size == 0 | @      // nothing left to flush
     | !@_is_writable          | error! // can't flush right now
-    | Platform.windows        | @_write_flush_windows!
+    | Platform.is_windows     | @_write_flush_windows!
     |                           @_write_flush_posix!
     )
 

--- a/src/lib.savi
+++ b/src/lib.savi
@@ -1,10 +1,10 @@
-:ffi LibC
+:ffimodule LibC
   :fun getsockopt(
     fd U32, level I32, option I32
     out_value CPointer(U8), out_length CPointer(USize)
   ) I32
 
-:ffi LibPonyOs
+:ffimodule LibPonyOs
   :fun pony_os_sockopt_level(level I32) I32
   :fun pony_os_sockopt_option(option I32) I32
   :fun pony_os_connect_tcp(owner AsioEventNotify, host CPointer(U8), service CPointer(U8), from CPointer(U8), asio_flags U32) U32


### PR DESCRIPTION
- Prefer `:ffimodule` over `:ffi`.
- Prefer `Platform.is_windows` over `Platform.windows`.