### PR TITLE
Expose the `event_id` for an `IO.CoreEngine`.

### DIFF
--- a/src/IO.savi
+++ b/src/IO.savi
@@ -41,7 +41,7 @@
   :copies _WriteBuffer
   :is ByteStream.Sink
 
-  :var _event_id AsioEvent.ID: CPointer(AsioEvent.ID.Opaque).null // TODO: AsioEvent.ID.null
+  :var _event_id AsioEvent.ID: AsioEvent.ID.null
   :var _fd U32: -1
   :var _os_error: OSError.None
   :var _pending_connect_count U32: 0
@@ -60,9 +60,13 @@
 
   :fun os_error: @_os_error
 
-  :new
+  :: Create an `IO.CoreEngine` associated with the given `AsioEvent.ID`.
+  :new (@_event_id)
 
-  // TODO: Make private or move to another package:
+  :: Get the `AsioEvent.ID` associated with this `IO.CoreEngine`.
+  :fun event_id: @_event_id
+
+  :: DEPRECATED: Use `new` with an `AsioEvent.ID` instead.
   :new new_tcp_connect!(
     actor AsioEvent.Actor
     host String
@@ -80,7 +84,7 @@
     if (connect_count == 0) error!
     @_pending_connect_count = connect_count
 
-  // TODO: Make private or move to another package:
+  :: DEPRECATED: Use `new` with an `AsioEvent.ID` instead.
   :new new_from_fd_rw(actor AsioEvent.Actor, @_fd)
     asio_flags = if Platform.is_windows (
       AsioEvent.Flags.read_write
@@ -89,13 +93,13 @@
     )
     @_event_id = _FFI.pony_asio_event_create(actor, @_fd, asio_flags, 0, True)
 
-  // TODO: Make private or move to another package:
+  :: DEPRECATED: Use `new` with an `AsioEvent.ID` instead.
   :new new_from_fd_r(actor AsioEvent.Actor, @_fd)
     asio_flags = AsioEvent.Flags.read
     @_event_id = _FFI.pony_asio_event_create(actor, @_fd, asio_flags, 0, True)
 
   :fun ref _clear_state_after_final_dispose
-    @_event_id = CPointer(AsioEvent.ID.Opaque).null // TODO: AsioEvent.ID.null
+    @_event_id = AsioEvent.ID.null
     @_fd = -1
     @_has_closed = True
     @_is_readable = False


### PR DESCRIPTION
Also shift support toward expecting a provided `event_id` in the
constructor, deprecating all the constructors that create one.