### PR TITLE
Avoid segfault on failed TCP connection opening.

### DIFF
--- a/src/IO.savi
+++ b/src/IO.savi
@@ -189,6 +189,9 @@
         )
       )
 
+    | @_event_id.is_null |
+      // ignore
+
     // Otherwise, this is an event that we don't own and don't want to own,
     // so we unsubscribe from it, allowing it to become disposable later,
     // at which point it will finally get cleaned up and freed.

--- a/src/IO.savi
+++ b/src/IO.savi
@@ -189,8 +189,8 @@
         )
       )
 
+    // ignore
     | @_event_id.is_null |
-      // ignore
 
     // Otherwise, this is an event that we don't own and don't want to own,
     // so we unsubscribe from it, allowing it to become disposable later,


### PR DESCRIPTION
This can occur when e.g. `TCP.Engine.new` fails to connect, in which case it will initialize `IO.CoreEngine` with an `AsioEvent.ID.null`. `_FFI.pony_asio_event_unsubscribe` will later segfault when NULL is passed.

Bug found by starting a `TCP.Engine` "connection", while the MQTT broker was not started, in which case it would segfault. 