### PR TITLE
Add public method for `IO.Engine.adopt_event!`.

### DIFF
--- a/src/IO.savi
+++ b/src/IO.savi
@@ -137,6 +137,11 @@
       error!
     )
 
+  :fun ref adopt_event!(event AsioEvent)
+    if @is_open @hard_close
+    @_adopt_event!(event)
+    @
+
   :fun ref _adopt_event!(event AsioEvent) @
     fd = _FFI.pony_asio_event_fd(event.id)
     os_error = _FFI.Util.check_os_error(fd)
@@ -277,6 +282,7 @@
       )
 
       _FFI.pony_os_socket_close(@_fd)
+      @_fd = -1
       @_has_closed = True
       @_is_send_shutdown = True
       @_is_recv_shutdown = True


### PR DESCRIPTION
This is what the `TCP` package will use for adopting an event from one of the pending parallel connection attempts.

This is a step toward getting the rest of the TCP-coupled code out of the `IO` library and into the `TCP` library where it belongs.