### PR TITLE
Fix: Use `OSError.from_u32!` instead of non-existent `from_u64!`.

### DIFF
--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -81,8 +81,7 @@
       option.resize_possibly_including_uninitialized_memory(options_size_value)
 
       // Convert the 4-byte array to the equivalent 32-bit OSError value.
-      // TODO: Should OSError enum provide a from_u32! method?
-      try (OSError.from_u64!(option.read_native_u32!(0).u64) | OSError.EINVAL)
+      try (OSError.from_u32!(option.read_native_u32!(0)) | OSError.EINVAL)
     )
 
   // POSIX-specific helpers


### PR DESCRIPTION
The `from_u64!` function worked when `OSError` was an `:enum`, but it stopped being an enum when we needed to support using different values for certain errors on different platforms.

This code has been broken since that change away from being an enum.

This commit fixes the code by using the newly introduced `from_u32!` function that is now provided by `OSError`.